### PR TITLE
Add EKS Prometheus workload

### DIFF
--- a/docs/developers/eks-demo.md
+++ b/docs/developers/eks-demo.md
@@ -64,5 +64,20 @@ kubectl -n aws-otel-eks describe deployment aws-otel-eks-sidecar
 
 The example template provided runs the AWS-OTel-Collector as sidecar to send application metrics and traces on Amazon EKS. We run two applications: the customer’s application (`aws-otel-emitter`) and the AWSOTelCollector `aws-otel-collector`. Running the AWSOTelCollector in the same application as the main application allows the AWSOTelCollector to collect the metric/trace data for the customer’s application. We also call running the AWSOTelCollector in this way a "Sidecar". 
 
+#### Deploy AWSOtelCollector on Amazon EKS with Prometheus metrics traffic
+If you want to use a sample workload with Prometheus metrics, deploy the [eks-prometheus.yaml](../../examples/eks/eks-prometheus.yaml) config.
+1. Deploy the application.
+```bash
+kubectl apply -f examples/eks/eks-prometheus.yaml
+```
+2. View the resources in the `aws-otel-eks` namespace.
+```bash
+kubectl get all -n aws-otel-eks
+```
+3. View the details of the deployed deployment.
+```bash
+kubectl -n aws-otel-eks describe deployment collector
+```
+
 **View Your Metrics**  
 You should now be able to view your metrics in your [CloudWatch console](https://console.aws.amazon.com/cloudwatch/). In the navigation bar, click on **Metrics**. The collected AWSOTelCollector metrics can be found in the **AWSObservability/CloudWatchOTService** namespace. Ensure that your region is set to the region set for your cluster.

--- a/examples/eks/eks-prometheus.yaml
+++ b/examples/eks/eks-prometheus.yaml
@@ -1,0 +1,133 @@
+# create namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: aws-otel-eks
+  labels:
+    name: aws-otel-eks
+
+---
+
+# create collector service account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: collector
+  namespace: aws-otel-eks
+
+---
+
+# create cluster role for collector
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: collector-role
+rules:
+  - apiGroups: [""]
+    resources:
+    - nodes
+    - nodes/proxy
+    - services
+    - endpoints
+    - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+
+---
+
+# create role binding for AOC
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: collector-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: collector
+    namespace: aws-otel-eks
+roleRef:
+  kind: ClusterRole
+  name: collector-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# create collector deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: collector
+  namespace: aws-otel-eks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: collector
+  template:
+    metadata:
+      labels:
+        app: collector
+    spec:
+      containers:
+        - name: aoc-collector
+          image: kohrapha/awscollector:v0.2.0
+          imagePullPolicy: Always
+          command: ["/awscollector"]
+          args: ["--config=/etc/otel-config.yaml", "--log-level=DEBUG"]
+          resources:
+            limits:
+              cpu:  1000m
+              memory: 1000Mi
+            requests:
+              cpu: 200m
+              memory: 200Mi
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: collector
+
+---
+
+# Create traffic generation service
+apiVersion: v1
+kind: Service
+metadata:
+  name: prom-app-service
+  namespace: aws-otel-eks
+  labels:
+    app: prom-app
+spec:
+  ports:
+  - name: web
+    port: 8081
+    targetPort: 8081
+    protocol: TCP
+  selector:
+    app: prom-app
+  type: NodePort
+
+---
+
+# create traffic generator deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prom-app
+  namespace: aws-otel-eks
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: prom-app
+  template:
+    metadata:
+      labels:
+        app: prom-app
+    spec:
+      containers:
+        - name: traffic-generator
+          image: supergiantkir/prometheus-test-app:latest
+          imagePullPolicy: Always


### PR DESCRIPTION
**Description:** 
Create EKS Prometheus workload. The workload uses a sample traffic generator image `supergiantkir/prometheus-test-app` that exports Prometheus metrics for the collector to scrape from.

**Testing:**
Ran the set up locally.

**Documentation:**
The EKS docs were updated to include this new workload.
