### PR TITLE
Implement ECS NGINX workload

### DIFF
--- a/examples/ecs/prometheus-nginx-workload/Dockerfile
+++ b/examples/ecs/prometheus-nginx-workload/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/examples/ecs/prometheus-nginx-workload/README.md
+++ b/examples/ecs/prometheus-nginx-workload/README.md
@@ -1,2 +1,13 @@
 ### Steps:
-1. Build the reverse-proxy container: `docker build -t kohrapha/reverse-proxy .`
+1. Build the reverse-proxy container and push the image:
+```
+docker build -t kohrapha/reverse-proxy .
+docker push kohrapha/reverse-proxy`
+```
+2. Configure `config.yaml` with `sample-config.yml`.
+2. Build and push AOC image:
+```
+make docker-build
+make docker-push
+```
+3. Upload task definition (`ecs-nginx-sidecar.json`) to ECS.

--- a/examples/ecs/prometheus-nginx-workload/README.md
+++ b/examples/ecs/prometheus-nginx-workload/README.md
@@ -1,0 +1,2 @@
+### Steps:
+1. Build the reverse-proxy container: `docker build -t kohrapha/reverse-proxy .`

--- a/examples/ecs/prometheus-nginx-workload/ecs-nginx-sidecar.json
+++ b/examples/ecs/prometheus-nginx-workload/ecs-nginx-sidecar.json
@@ -130,9 +130,9 @@
       },
       {
         "name": "aws-otel-collector",
-        "image": "kohrapha/awscollector:v0.1.13",
-        "cpu": "100",
-        "memory": "100",
+        "image": "kohrapha/awscollector:v0.1.0",
+        "cpu": "1000",
+        "memory": "1000",
         "portMappings": [
           {
             "containerPort": 55680,
@@ -141,9 +141,10 @@
           }
         ],
         "essential": true,
-        "entryPoint": [],
-        "command": [],
-        "environment": [],
+        "command": ["--config=/etc/otel-config.yaml", "--log-level=DEBUG"],
+        "links": [
+          "nginx-prometheus-exporter"
+        ],
         "dependsOn": [],
         "logConfiguration": {
           "logDriver": "awslogs",

--- a/examples/ecs/prometheus-nginx-workload/ecs-nginx-sidecar.json
+++ b/examples/ecs/prometheus-nginx-workload/ecs-nginx-sidecar.json
@@ -1,0 +1,134 @@
+{
+    "family": "aoc-ec2-nginx",
+    "taskRoleArn": "{{ecsTaskRoleArn}}",
+    "executionRoleArn": "{{ecsExecutionRoleArn}}",
+    "networkMode": "bridge",
+    "containerDefinitions": [
+      {
+        "name": "apple",
+        "image": "hashicorp/http-echo",
+        "essential": true,
+        "command": ["-text=apple"],
+        "portMappings": [
+          {
+            "containerPort": 5678,
+            "hostPort": 5678
+          }
+        ],
+        "dependsOn": [],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/aoc-ec2-nginx-apple",
+            "awslogs-region": "{{region}}",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        }
+      },
+      {
+        "name": "banana",
+        "image": "hashicorp/http-echo",
+        "essential": true,
+        "command": ["-text=banana"],
+        "dependsOn": [],
+        "portMappings": [
+          {
+            "containerPort": 5678,
+            "hostPort": 5678
+          }
+        ],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/aoc-ec2-nginx-banana",
+            "awslogs-region": "{{region}}",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        }
+      },
+      {
+        "name": "nginx-reverse-proxy",
+        "image": "<nginx-reverse-proxy-image-url>",
+        "essential": true,
+        "portMappings": [
+          {
+            "containerPort": 80
+          }
+        ],
+        "links": [
+          "apple",
+          "banana"
+        ],
+        "dependsOn": [],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/aoc-ecs-nginx-reverse-proxy",
+            "awslogs-region": "{{region}}",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        }
+      },
+      {
+        "name": "traffic-generator",
+        "image": "ellerbrock/alpine-bash-curl-ssl",
+        "essential": true,
+        "command": ["/bin/bash", "-c", "while :; do curl http://{{external_ip}}/apple > /dev/null 2>&1; curl http://{{external_ip}}/banana > /dev/null 2>&1; sleep 1; done"],
+        "portMappings": [
+          {
+            "containerPort": 5678,
+            "hostPort": 5678
+          }
+        ],
+        "dependsOn": [
+          {
+            "containerName": "nginx-reverse-proxy",
+            "condition": "START"
+          }
+        ],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/aoc-ec2-nginx-traffic-generator",
+            "awslogs-region": "{{region}}",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        }
+      },
+      {
+        "name": "aws-otel-collector",
+        "image": "aottestbed/awscollector:v0.1.12",
+        "portMappings": [
+          {
+            "containerPort": 55680,
+            "hostPort": 55680,
+            "protocol": "tcp"
+          }
+        ],
+        "essential": true,
+        "entryPoint": [],
+        "command": [],
+        "environment": [],
+        "dependsOn": [],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/ecs-aws-otel-sidecar-collector",
+            "awslogs-region": "{{region}}",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        }
+      }
+    ],
+    "requiresCompatibilities": [
+      "EC2"
+    ],
+    "cpu": "256",
+    "memory": "512"
+  }
+  

--- a/examples/ecs/prometheus-nginx-workload/ecs-nginx-sidecar.json
+++ b/examples/ecs/prometheus-nginx-workload/ecs-nginx-sidecar.json
@@ -1,18 +1,19 @@
 {
     "family": "aoc-ec2-nginx",
-    "taskRoleArn": "{{ecsTaskRoleArn}}",
-    "executionRoleArn": "{{ecsExecutionRoleArn}}",
+    "taskRoleArn": "ecs-aoc",
+    "executionRoleArn": "ecs-aoc",
     "networkMode": "bridge",
     "containerDefinitions": [
       {
         "name": "apple",
         "image": "hashicorp/http-echo",
+        "cpu": "100",
+        "memory": "100",
         "essential": true,
         "command": ["-text=apple"],
         "portMappings": [
           {
-            "containerPort": 5678,
-            "hostPort": 5678
+            "containerPort": 5678
           }
         ],
         "dependsOn": [],
@@ -20,7 +21,7 @@
           "logDriver": "awslogs",
           "options": {
             "awslogs-group": "/ecs/aoc-ec2-nginx-apple",
-            "awslogs-region": "{{region}}",
+            "awslogs-region": "us-west-2",
             "awslogs-stream-prefix": "ecs",
             "awslogs-create-group": "True"
           }
@@ -29,20 +30,47 @@
       {
         "name": "banana",
         "image": "hashicorp/http-echo",
+        "cpu": "100",
+        "memory": "100",
         "essential": true,
         "command": ["-text=banana"],
         "dependsOn": [],
         "portMappings": [
           {
-            "containerPort": 5678,
-            "hostPort": 5678
+            "containerPort": 5678
           }
         ],
         "logConfiguration": {
           "logDriver": "awslogs",
           "options": {
             "awslogs-group": "/ecs/aoc-ec2-nginx-banana",
-            "awslogs-region": "{{region}}",
+            "awslogs-region": "us-west-2",
+            "awslogs-stream-prefix": "ecs",
+            "awslogs-create-group": "True"
+          }
+        }
+      },
+      {
+        "name": "traffic-generator",
+        "image": "ellerbrock/alpine-bash-curl-ssl",
+        "cpu": "100",
+        "memory": "100",
+        "essential": true,
+        "command": ["/bin/bash", "-c", "while :; do curl http://nginx-reverse-proxy/apple > /dev/null 2>&1; curl http://nginx-reverse-proxy/banana > /dev/null 2>&1; sleep 1; done"],
+        "dependsOn": [
+          {
+            "containerName": "nginx-reverse-proxy",
+            "condition": "START"
+          }
+        ],
+        "links": [
+          "nginx-reverse-proxy"
+        ],
+        "logConfiguration": {
+          "logDriver": "awslogs",
+          "options": {
+            "awslogs-group": "/ecs/aoc-ec2-nginx-traffic-generator",
+            "awslogs-region": "us-west-2",
             "awslogs-stream-prefix": "ecs",
             "awslogs-create-group": "True"
           }
@@ -50,7 +78,9 @@
       },
       {
         "name": "nginx-reverse-proxy",
-        "image": "<nginx-reverse-proxy-image-url>",
+        "image": "kohrapha/reverse-proxy",
+        "cpu": "256",
+        "memory": "256",
         "essential": true,
         "portMappings": [
           {
@@ -66,34 +96,33 @@
           "logDriver": "awslogs",
           "options": {
             "awslogs-group": "/ecs/aoc-ecs-nginx-reverse-proxy",
-            "awslogs-region": "{{region}}",
+            "awslogs-region": "us-west-2",
             "awslogs-stream-prefix": "ecs",
             "awslogs-create-group": "True"
           }
         }
       },
       {
-        "name": "traffic-generator",
-        "image": "ellerbrock/alpine-bash-curl-ssl",
+        "name": "nginx-prometheus-exporter",
+        "image": "nginx/nginx-prometheus-exporter:0.8.0",
+        "cpu": "256",
+        "memory": "256",
         "essential": true,
-        "command": ["/bin/bash", "-c", "while :; do curl http://{{external_ip}}/apple > /dev/null 2>&1; curl http://{{external_ip}}/banana > /dev/null 2>&1; sleep 1; done"],
+        "command": ["-nginx.scrape-uri", "http://nginx-reverse-proxy:80/metrics"],
         "portMappings": [
           {
-            "containerPort": 5678,
-            "hostPort": 5678
+            "containerPort": 9113
           }
         ],
-        "dependsOn": [
-          {
-            "containerName": "nginx-reverse-proxy",
-            "condition": "START"
-          }
+        "links": [
+          "nginx-reverse-proxy"
         ],
+        "dependsOn": [],
         "logConfiguration": {
           "logDriver": "awslogs",
           "options": {
-            "awslogs-group": "/ecs/aoc-ec2-nginx-traffic-generator",
-            "awslogs-region": "{{region}}",
+            "awslogs-group": "/ecs/aoc-ecs-nginx-prometheus-exporter",
+            "awslogs-region": "us-west-2",
             "awslogs-stream-prefix": "ecs",
             "awslogs-create-group": "True"
           }
@@ -101,7 +130,9 @@
       },
       {
         "name": "aws-otel-collector",
-        "image": "aottestbed/awscollector:v0.1.12",
+        "image": "kohrapha/awscollector:v0.1.13",
+        "cpu": "100",
+        "memory": "100",
         "portMappings": [
           {
             "containerPort": 55680,
@@ -117,8 +148,8 @@
         "logConfiguration": {
           "logDriver": "awslogs",
           "options": {
-            "awslogs-group": "/ecs/ecs-aws-otel-sidecar-collector",
-            "awslogs-region": "{{region}}",
+            "awslogs-group": "/ecs/aoc-ecs-collector",
+            "awslogs-region": "us-west-2",
             "awslogs-stream-prefix": "ecs",
             "awslogs-create-group": "True"
           }
@@ -127,8 +158,6 @@
     ],
     "requiresCompatibilities": [
       "EC2"
-    ],
-    "cpu": "256",
-    "memory": "512"
+    ]
   }
   

--- a/examples/ecs/prometheus-nginx-workload/nginx.conf
+++ b/examples/ecs/prometheus-nginx-workload/nginx.conf
@@ -1,0 +1,17 @@
+events {
+  worker_connections 768;
+}
+
+http {
+  server {
+    listen 80;
+
+    location /apple {
+      proxy_pass http://apple:5678;
+    }
+
+    location /banana {
+      proxy_pass http://banana:5678;
+    }
+  }
+}

--- a/examples/ecs/prometheus-nginx-workload/nginx.conf
+++ b/examples/ecs/prometheus-nginx-workload/nginx.conf
@@ -13,5 +13,9 @@ http {
     location /banana {
       proxy_pass http://banana:5678;
     }
+
+    location /metrics {
+      stub_status;
+    }
   }
 }

--- a/examples/ecs/prometheus-nginx-workload/sample-config.yml
+++ b/examples/ecs/prometheus-nginx-workload/sample-config.yml
@@ -1,0 +1,26 @@
+extensions:
+    health_check:
+  
+  receivers:
+    prometheus:
+      config:
+        scrape_configs:
+        - job_name: ec2
+          static_configs:
+          - targets: ['nginx-prometheus-exporter:9113']
+  
+  exporters:
+    awsemf:
+      log_group_name: 'awscollector'
+      region: 'us-west-2'
+      log_stream_name: otel-stream
+      dimension_rollup_option: 'NoDimensionRollup'
+  
+  service:
+    pipelines:
+      metrics:
+        receivers: [prometheus]
+        exporters: [awsemf]
+  
+    extensions: [health_check]
+  


### PR DESCRIPTION
**Description:**
This PR implements the sample ECS workload for Prometheus metrics. It includes 2 sample endpoints and a reverse NGINX proxy that exports Prometheus metrics based on the observed traffic flowing into the sample apps.

**Documentation:**
A README file was added that details the required steps to implement this sample workload.
