### PR TITLE
Configure Prometheus receiver and create script for sample set-up

### DIFF
--- a/examples/eks/prometheus-nginx-workload/eks-aoc-nginx.yaml
+++ b/examples/eks/prometheus-nginx-workload/eks-aoc-nginx.yaml
@@ -1,0 +1,108 @@
+# create namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{namespace}}
+  labels:
+    name: {{namespace}}
+
+---
+
+# create aoc service account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aoc-prometheus
+  namespace: {{namespace}}
+
+---
+
+# create cluster role for AOC
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aoc-prometheus-role
+rules:
+  - apiGroups: [""]
+    resources:
+    - nodes
+    - nodes/proxy
+    - services
+    - endpoints
+    - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+
+---
+
+# create role binding for AOC
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aoc-prometheus-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: aoc-prometheus
+    namespace: {{namespace}}
+roleRef:
+  kind: ClusterRole
+  name: aoc-prometheus-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# create AOC deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aoc-prometheus
+  namespace: {{namespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aoc-prometheus
+  template:
+    metadata:
+      labels:
+        app: aoc-prometheus
+    spec:
+      containers:
+        - name: aoc-collector
+          image: kohrapha/awscollector:v0.1.13
+          imagePullPolicy: Always
+          command: ["/awscollector"]
+          args: ["--config=/etc/otel-config.yaml", "--log-level=DEBUG"]
+          resources:
+            limits:
+              cpu:  1000m
+              memory: 1000Mi
+            requests:
+              cpu: 200m
+              memory: 200Mi
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              value: {{aws_id}}
+            - name: AWS_SECRET_ACCESS_KEY
+              value: {{aws_secret}}
+            - name: AWS_REGION
+              value: {{region}}
+          ports:
+            - containerPort: 17777
+              name: pprof-ext
+            - containerPort: 55679
+              name: zpages-ext
+            - containerPort: 55680
+              name: otlp-receiver
+            - containerPort: 13133
+              name: health-check
+            - containerPort: 8888
+              name: prometheus
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: aoc-prometheus

--- a/examples/eks/prometheus-nginx-workload/prom-aoc.sh
+++ b/examples/eks/prometheus-nginx-workload/prom-aoc.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+AOC_NAMESPACE=eks-aoc
+TRAFFIC_NAMESPACE=eks-traffic
+AWS_ID=<dummy>
+AWS_SECRET=<dummy>
+AWS_REGION=us-west-2
+
+# exit when any command fails and propagate pipe errors
+set -eo pipefail
+
+err_report() {
+    echo "Error on line $1: $BASH_COMMAND"
+}
+
+trap 'err_report ${LINENO}' ERR
+
+function setup {
+    printf "Initiating Prometheus AOC setup...\n\n"
+    kubectl create namespace $AOC_NAMESPACE
+
+    # Install NGINX Ingress Controller and enable Prometheus metrics
+    helm install my-nginx ingress-nginx/ingress-nginx \
+        --namespace $AOC_NAMESPACE \
+        --set controller.metrics.enabled=true \
+        --set-string controller.metrics.service.annotations."prometheus\.io/port"="10254" \
+        --set-string controller.metrics.service.annotations."prometheus\.io/scrape"="true" \
+        >/dev/null
+
+    # Get external IP address of NGINX Ingress controller
+    EXTERNAL_IP=$(kubectl get svc -n $AOC_NAMESPACE my-nginx-ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+    printf "\nNGINX Ingress Controller installed and exposed at: $EXTERNAL_IP.\n\n"
+
+    # Attach AOC service
+    cat examples/eks/prometheus-nginx-workload/eks-aoc-nginx.yaml |
+        sed "s/{{namespace}}/$AOC_NAMESPACE/g" |
+        sed "s/{{aws_id}}/$AWS_ID/g" |
+        sed "s/{{aws_secret}}/$AWS_SECRET/g" |
+        sed "s/{{region}}/$AWS_REGION/g" |
+        kubectl apply -f -
+    printf "\nAOC successfully installed.\n\n"
+    
+    # Set up sample traffic server
+    curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/master/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/nginx-traffic-sample.yaml |
+        sed "s/{{external_ip}}/$EXTERNAL_IP/g" |
+        sed "s/{{namespace}}/$TRAFFIC_NAMESPACE/g" |
+        kubectl apply -f -
+    printf "\nSample traffic server set up.\n\n"
+
+    echo "Prometheus AOC setup complete!"
+}
+
+function teardown {
+    printf "Initiating teardown sequence...\n\n"
+    kubectl delete namespace $TRAFFIC_NAMESPACE
+    helm uninstall my-nginx --namespace $AOC_NAMESPACE
+    kubectl delete namespace $AOC_NAMESPACE
+}
+
+subcommand=$1
+case "$subcommand" in
+    "")
+        setup
+        ;;
+    --teardown | -t)
+        teardown
+        ;;
+    *)
+        echo "Invalid command: $subcommand"
+        exit 1
+        ;;
+esac

--- a/examples/eks/prometheus-nginx-workload/sample-config.yaml
+++ b/examples/eks/prometheus-nginx-workload/sample-config.yaml
@@ -1,0 +1,75 @@
+extensions:
+    health_check:
+  
+  receivers:
+    prometheus:
+      config:
+        scrape_configs:
+        - job_name: kubernetes-service-endpoints
+          sample_limit: 10000
+          kubernetes_sd_configs:
+          - role: endpoints
+          relabel_configs:
+          - action: keep
+            regex: true
+            source_labels:
+            - __meta_kubernetes_service_annotation_prometheus_io_scrape
+          - action: replace
+            regex: (https?)
+            source_labels:
+            - __meta_kubernetes_service_annotation_prometheus_io_scheme
+            target_label: __scheme__
+          - action: replace
+            regex: (.+)
+            source_labels:
+            - __meta_kubernetes_service_annotation_prometheus_io_path
+            target_label: __metrics_path__
+          - action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $$1:$$2
+            source_labels:
+            - __address__
+            - __meta_kubernetes_service_annotation_prometheus_io_port
+            target_label: __address__
+          - action: labelmap
+            regex: __meta_kubernetes_service_label_(.+)
+          - action: replace
+            source_labels:
+            - __meta_kubernetes_namespace
+            target_label: Namespace
+          - action: replace
+            source_labels:
+            - __meta_kubernetes_service_name
+            target_label: Service
+          - action: replace
+            source_labels:
+            - __meta_kubernetes_pod_node_name
+            target_label: kubernetes_node
+          - action: replace
+            source_labels:
+            - __meta_kubernetes_pod_name
+            target_label: pod_name
+          - action: replace
+            source_labels:
+            - __meta_kubernetes_pod_container_name
+            target_label: container_name
+          metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: 'go_gc_duration_seconds.*'
+            action: drop
+  
+  exporters:
+    awsemf:
+      log_group_name: 'awscollector'
+      region: 'us-west-2'
+      log_stream_name: otel-stream
+      dimension_rollup_option: 'NoDimensionRollup'
+  
+  service:
+    pipelines:
+      metrics:
+        receivers: [prometheus]
+        exporters: [awsemf]
+  
+    extensions: [health_check]
+  


### PR DESCRIPTION
This PR accomplishes the following:
1. Configure AOC Prometheus receiver to scrape Prometheus metrics via automatic service discovery.
2. Create script for sample NGINX workload with Prometheus metrics.

## Architecture Overview
<p align="center">
<img src="https://user-images.githubusercontent.com/19257435/94193012-c48a8180-fe7d-11ea-9129-7e9e27a25124.png" width="500px" />
</p>

1. We create an NGINX Ingress controller which uses NGINX as a reverse proxy for managing access to services within a cluster.
2. We attach the AOC container as a service, defined by `examples/eks/eks-aoc-nginx.yaml`, in the same namespace (`eks-aoc`) as the NGINX Ingress controller we deployed in Step 1. 
3. We configure the AOC Prometheus receiver to perform automatic service discovery under `receivers.prometheus.config.scrape_configs` in `config.yaml`. This will detect the exposed port in the NGINX Ingress controller and scrape Prometheus metrics from there.
4. Finally, we deploy the sample traffic cluster to a new namespace (`eks-traffic`) which sends pings to the server at regular intervals. We configure the cluster to use the NGINX Ingress controller as its Ingress controller. This redirects all http requests to the server through the NGINX reverse proxy.
5. As requests pass through the NGINX Ingress controller, Prometheus metrics are created and exposed at a defined port.
6. AOC then scrapes those metrics from that port at defined intervals and pushes them through the OTEL pipeline to be exported to CW console.

## Using the script
### Set up
To set up this example, run `examples/eks/prom-aoc.sh` which will deploy the setup listed above. You might get an error saying:
```bash
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post https://my-nginx-ingress-nginx-controller-admission.eks-aoc.svc:443/networking/v1beta1/ingresses?timeout=10s: no endpoints available for service "my-nginx-ingress-nginx-controller-admission"
```
There is [a thread](https://github.com/kubernetes/ingress-nginx/issues/5401) regarding this error. However, you can just ignore it; the deployment will still work. If you want, you can run the commands manually yourself, and the error won't appear. My guess is that the script sets up the traffic server too fast for the NGINX Ingress controller to finish getting set up.

### Tear down
Once done with this example, you can perform tear down by running: `examples/eks/prom-aoc.sh --teardown` or `examples/eks/prom-aoc.sh -t`.

## Issues faced
1. Had a tough time using regex group matching within `config.yaml`. This was because `$FOO` is treated as an env var, so we need to use `$$FOO`. Relevant issue regarding why `$` fails for regexes in config: https://github.com/open-telemetry/opentelemetry-collector/issues/1077


